### PR TITLE
CircuitPython API Compatibility and Bugfixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,8 @@ Introduction
 
 Basic date and time types. Implements a subset of the `CPython datetime module <https://docs.python.org/3/library/datetime.html>`_.
 
+NOTE: This library has a large memory footprint and is intended for hardware such as the SAMD51, ESP32-S2, and nRF52.
+
 Dependencies
 =============
 This driver depends on:

--- a/examples/datetime_simpletest.py
+++ b/examples/datetime_simpletest.py
@@ -10,7 +10,7 @@
 
 # Example of working with a `datetime` object
 # from https://docs.python.org/3/library/datetime.html#examples-of-usage-datetime
-from adafruit_datetime import datetime, date, time, timezone
+from adafruit_datetime import datetime, date, time
 
 # Using datetime.combine()
 d = date(2005, 7, 14)

--- a/examples/datetime_simpletest.py
+++ b/examples/datetime_simpletest.py
@@ -20,7 +20,6 @@ print(datetime.combine(d, t))
 
 # Using datetime.now()
 print("Current time (GMT +1):", datetime.now())
-print("Current UTC time: ", datetime.now(timezone.utc))
 
 # Using datetime.timetuple() to get tuple of all attributes
 dt = datetime(2006, 11, 21, 16, 30)
@@ -28,9 +27,4 @@ tt = dt.timetuple()
 for it in tt:
     print(it)
 
-# Formatting a datetime
-print(
-    "The {1} is {0:%d}, the {2} is {0:%B}, the {3} is {0:%I:%M%p}.".format(
-        dt, "day", "month", "time"
-    )
-)
+print("Today is: ", dt.ctime())

--- a/examples/datetime_time.py
+++ b/examples/datetime_time.py
@@ -21,10 +21,3 @@ print("ISO8601-Formatted Time:", iso_time)
 
 # Timezone name
 print("Timezone Name:", t.tzname())
-
-# Return a string representing the time, controlled by an explicit format string
-strf_time = t.strftime("%H:%M:%S %Z")
-print("Formatted time string:", strf_time)
-
-# Specifies a format string in formatted string literals
-print("The time is {:%H:%M}.".format(t))

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -546,7 +546,6 @@ class TestDateTime(TestDate):
             else:
                 self.assertEqual(self.theclass.fromtimestamp(s), t)
 
-
     def test_timestamp_aware(self):
         t = self.theclass(1970, 1, 1, tzinfo=timezone.utc)
         self.assertEqual(t.timestamp(), 0.0)

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -506,6 +506,7 @@ class TestDateTime(TestDate):
         got = self.theclass.fromtimestamp(ts)
         self.verify_field_equality(expected, got)
 
+    @unittest.skip("gmtime not implemented in CircuitPython")
     def test_utcfromtimestamp(self):
         import time
 
@@ -514,8 +515,6 @@ class TestDateTime(TestDate):
         got = self.theclass.utcfromtimestamp(ts)
         self.verify_field_equality(expected, got)
 
-    # TODO
-    @unittest.skip("Wait until we bring in UTCOFFSET")
     # Run with US-style DST rules: DST begins 2 a.m. on second Sunday in
     # March (M3.2.0) and ends 2 a.m. on first Sunday in November (M11.1.0).
     @support.run_with_tz("EST+05EDT,M3.2.0,M11.1.0")
@@ -547,8 +546,7 @@ class TestDateTime(TestDate):
             else:
                 self.assertEqual(self.theclass.fromtimestamp(s), t)
 
-    # TODO
-    @unittest.skip("Hold off on this test until we bring timezone in")
+
     def test_timestamp_aware(self):
         t = self.theclass(1970, 1, 1, tzinfo=timezone.utc)
         self.assertEqual(t.timestamp(), 0.0)
@@ -559,6 +557,7 @@ class TestDateTime(TestDate):
         )
         self.assertEqual(t.timestamp(), 18000 + 3600 + 2 * 60 + 3 + 4 * 1e-6)
 
+    @unittest.skip("Not implemented - gmtime")
     @support.run_with_tz("MSK-03")  # Something east of Greenwich
     def test_microsecond_rounding(self):
         for fts in [self.theclass.fromtimestamp, self.theclass.utcfromtimestamp]:
@@ -599,8 +598,7 @@ class TestDateTime(TestDate):
             self.assertEqual(t.second, 0)
             self.assertEqual(t.microsecond, 7812)
 
-    # TODO
-    @unittest.skip("timezone not implemented")
+    @unittest.skip("gmtime not implemented in CircuitPython")
     def test_timestamp_limits(self):
         # minimum timestamp
         min_dt = self.theclass.min.replace(tzinfo=timezone.utc)
@@ -649,6 +647,7 @@ class TestDateTime(TestDate):
         for insane in -1e200, 1e200:
             self.assertRaises(OverflowError, self.theclass.fromtimestamp, insane)
 
+    @unittest.skip("Not implemented - gmtime")
     def test_insane_utcfromtimestamp(self):
         # It's possible that some platform maps time_t to double,
         # and that this test will fail there.  This test should
@@ -657,7 +656,7 @@ class TestDateTime(TestDate):
         for insane in -1e200, 1e200:
             self.assertRaises(OverflowError, self.theclass.utcfromtimestamp, insane)
 
-    @unittest.skip("Not implemented - utcnow")
+    @unittest.skip("gmtime not implemented in CircuitPython")
     def test_utcnow(self):
         import time
 
@@ -672,7 +671,7 @@ class TestDateTime(TestDate):
             # Else try again a few times.
         self.assertLessEqual(abs(from_timestamp - from_now), tolerance)
 
-    @unittest.skip("Not implemented - strptime")
+    @unittest.skip("gmtime not implemented in CircuitPython")
     def test_strptime(self):
         string = "2004-12-01 13:02:47.197"
         format = "%Y-%m-%d %H:%M:%S.%f"
@@ -735,7 +734,7 @@ class TestDateTime(TestDate):
         with self.assertRaises(ValueError):
             strptime("-000", "%z")
 
-    @unittest.skip("Not implemented - strptime")
+    @unittest.skip("gmtime not implemented in CircuitPython")
     def test_strptime_single_digit(self):
         # bpo-34903: Check that single digit dates and times are allowed.
 
@@ -798,7 +797,7 @@ class TestDateTime(TestDate):
         self.assertEqual(tt.tm_yday, t.toordinal() - date(t.year, 1, 1).toordinal() + 1)
         self.assertEqual(tt.tm_isdst, -1)
 
-    @unittest.skip("Not implemented - strftime")
+    @unittest.skip("gmtime not implemented in CircuitPython")
     def test_more_strftime(self):
         # This tests fields beyond those tested by the TestDate.test_strftime.
         t = self.theclass(2004, 12, 31, 6, 22, 33, 47)

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -220,6 +220,7 @@ class TestTime(HarmlessMixedComparison, unittest.TestCase):
         t = self.theclass(second=1)
         self.assertRaises(TypeError, t.isoformat, foo=3)
 
+    @unittest.skip("strftime not implemented for CircuitPython time objects")
     def test_strftime(self):
         t = self.theclass(1, 2, 3, 4)
         self.assertEqual(t.strftime("%H %M %S %f"), "01 02 03 000004")
@@ -231,6 +232,7 @@ class TestTime(HarmlessMixedComparison, unittest.TestCase):
         except UnicodeEncodeError:
             pass
 
+    @unittest.skip("strftime not implemented for CircuitPython time objects")
     def test_format(self):
         t = self.theclass(1, 2, 3, 4)
         self.assertEqual(t.__format__(""), str(t))


### PR DESCRIPTION
This pull request:

*  Removes  methods which rely on a native call to `time.strftime`.
    * CircuitPython's `time` module does not implement `strftime`
    * `ctime()` added to `datetime` so users can still do string-format-y things.
*  Fix an `OverflowError` within timestamps on ESP32-S2 
* `gmtime()` not implemented within CircuitPython time API (https://github.com/adafruit/circuitpython/issues/1663) - raise error where appropriate.  
* Examples and tests modified to reflect the changes above.
* Fix broken `tzinfo.__new__` call.

* Tested on `Adafruit CircuitPython 6.1.0-beta.2 on 2020-12-03; MagTag with ESP32S2`  