### PR TITLE
Added fromisoformat() to date and datetime

### DIFF
--- a/adafruit_datetime.py
+++ b/adafruit_datetime.py
@@ -661,7 +661,7 @@ class date:
     @classmethod
     def fromisoformat(cls, date_string):
         """Return a date object constructed from an ISO date format.
-        Valid format is YYYY-MM-DD
+        Valid format is ``YYYY-MM-DD``
 
         """
         match = _re.match(
@@ -1224,7 +1224,7 @@ class datetime(date):
     @classmethod
     def fromisoformat(cls, date_string, tz=None):
         """Return a datetime object constructed from an ISO date format.
-        Valid format is YYYY-MM-DD[*HH[:MM[:SS[.fff[fff]]]]]
+        Valid format is ``YYYY-MM-DD[*HH[:MM[:SS[.fff[fff]]]]]``
 
         """
         match = _re.match(

--- a/adafruit_datetime.py
+++ b/adafruit_datetime.py
@@ -29,6 +29,7 @@ Implementation Notes
 # pylint: disable=too-many-lines
 import time as _time
 import math as _math
+import re as _re
 from micropython import const
 
 __version__ = "0.0.0-auto.0"
@@ -658,6 +659,18 @@ class date:
         return cls(y, m, d)
 
     @classmethod
+    def fromisoformat(cls, date_string):
+        """Return a date object constructed from an ISO date format."""
+        match = _re.match(
+            r"([0-9][0-9][0-9][0-9])-([0-9][0-9])-([0-9][0-9])", date_string
+        )
+        if match:
+            y, m, d = int(match.group(1)), int(match.group(2)), int(match.group(3))
+            return cls(y, m, d)
+        else:
+            raise ValueError("Not a valid ISO Date")
+
+    @classmethod
     def today(cls):
         """Return the current local date."""
         return cls.fromtimestamp(_time.time())
@@ -1205,6 +1218,35 @@ class datetime(date):
     @classmethod
     def fromtimestamp(cls, timestamp, tz=None):
         return cls._fromtimestamp(timestamp, tz is not None, tz)
+
+    @classmethod
+    def fromisoformat(cls, date_string, tz=None):
+        """Return a date object constructed from an ISO date format.
+        YYYY-MM-DD[*HH[:MM[:SS[.fff[fff]]]][+HH:MM[:SS[.ffffff]]]]
+        """
+        match = _re.match(
+            r"([0-9][0-9][0-9][0-9])-([0-9][0-9])-([0-9][0-9])(T([0-9][0-9]))?(:([0-9][0-9]))?(:([0-9][0-9]))?(\.[0-9][0-9][0-9][0-9][0-9][0-9])?",
+            date_string,
+        )
+        if match:
+            y, m, d = int(match.group(1)), int(match.group(2)), int(match.group(3))
+            hh = int(match.group(5)) if match.group(5) else 0
+            mm = int(match.group(5)) if match.group(7) else 0
+            ss = int(match.group(9)) if match.group(9) else 0
+            us = round((float("0" + match.group(10)) if match.group(10) else 0) * 1e6)
+            result = cls(
+                y,
+                m,
+                d,
+                hh,
+                mm,
+                ss,
+                us,
+                tz,
+            )
+            return result
+        else:
+            raise ValueError("Not a valid ISO Date")
 
     @classmethod
     def now(cls, timezone=None):

--- a/adafruit_datetime.py
+++ b/adafruit_datetime.py
@@ -1224,13 +1224,13 @@ class datetime(date):
     @classmethod
     def fromisoformat(cls, date_string, tz=None):
         """Return a datetime object constructed from an ISO date format.
-        Valid format is YYYY-MM-DD[*HH[:MM[:SS[.fff[fff]]]][+HH:MM[:SS[.ffffff]]]]
+        Valid format is YYYY-MM-DD[*HH[:MM[:SS[.fff[fff]]]]]
 
         """
         match = _re.match(
             (
-                r"([0-9][0-9][0-9][0-9])-([0-9][0-9])-([0-9][0-9])(T([0-9][0-9]))?(:([0-9][0-9]))"
-                r"?(:([0-9][0-9]))?(\.[0-9][0-9][0-9][0-9][0-9][0-9])?"
+                r"([0-9][0-9][0-9][0-9])-([0-9][0-9])-([0-9][0-9])(T([0-9][0-9]))?(:([0-9][0-9]))?"
+                r"(:([0-9][0-9]))?(\.([0-9][0-9][0-9])([0-9][0-9][0-9])?)?"
             ),
             date_string,
         )
@@ -1239,7 +1239,12 @@ class datetime(date):
             hh = int(match.group(5)) if match.group(5) else 0
             mm = int(match.group(5)) if match.group(7) else 0
             ss = int(match.group(9)) if match.group(9) else 0
-            us = round((float("0" + match.group(10)) if match.group(10) else 0) * 1e6)
+            us = 0
+            print(match.group(10))
+            if match.group(11):
+                us += int(match.group(11)) * 1000
+            if match.group(12):
+                us += int(match.group(12))
             result = cls(
                 y,
                 m,

--- a/adafruit_datetime.py
+++ b/adafruit_datetime.py
@@ -1262,6 +1262,11 @@ class datetime(date):
         """
         return self._tzinfo
 
+    @property
+    def fold(self):
+        """Fold."""
+        return self._fold
+
     # Class methods
 
     # pylint: disable=protected-access
@@ -1311,8 +1316,10 @@ class datetime(date):
         Valid format is ``YYYY-MM-DD[*HH[:MM[:SS[.fff[fff]]]][+HH:MM[:SS[.ffffff]]]]``
 
         """
-        if "T" in date_string:
-            date_string, time_string = date_string.split("T")
+        time_string = None
+        if len(date_string) > 10:
+            time_string = date_string[11:]
+            date_string = date_string[:10]
             dateval = date.fromisoformat(date_string)
             timeval = time.fromisoformat(time_string)
         else:

--- a/adafruit_datetime.py
+++ b/adafruit_datetime.py
@@ -660,7 +660,10 @@ class date:
 
     @classmethod
     def fromisoformat(cls, date_string):
-        """Return a date object constructed from an ISO date format."""
+        """Return a date object constructed from an ISO date format.
+        Valid format is YYYY-MM-DD
+
+        """
         match = _re.match(
             r"([0-9][0-9][0-9][0-9])-([0-9][0-9])-([0-9][0-9])", date_string
         )
@@ -1220,8 +1223,9 @@ class datetime(date):
 
     @classmethod
     def fromisoformat(cls, date_string, tz=None):
-        """Return a date object constructed from an ISO date format.
-        YYYY-MM-DD[*HH[:MM[:SS[.fff[fff]]]][+HH:MM[:SS[.ffffff]]]]
+        """Return a datetime object constructed from an ISO date format.
+        Valid format is YYYY-MM-DD[*HH[:MM[:SS[.fff[fff]]]][+HH:MM[:SS[.ffffff]]]]
+
         """
         match = _re.match(
             (

--- a/adafruit_datetime.py
+++ b/adafruit_datetime.py
@@ -667,8 +667,7 @@ class date:
         if match:
             y, m, d = int(match.group(1)), int(match.group(2)), int(match.group(3))
             return cls(y, m, d)
-        else:
-            raise ValueError("Not a valid ISO Date")
+        raise ValueError("Not a valid ISO Date")
 
     @classmethod
     def today(cls):
@@ -1225,7 +1224,10 @@ class datetime(date):
         YYYY-MM-DD[*HH[:MM[:SS[.fff[fff]]]][+HH:MM[:SS[.ffffff]]]]
         """
         match = _re.match(
-            r"([0-9][0-9][0-9][0-9])-([0-9][0-9])-([0-9][0-9])(T([0-9][0-9]))?(:([0-9][0-9]))?(:([0-9][0-9]))?(\.[0-9][0-9][0-9][0-9][0-9][0-9])?",
+            (
+                r"([0-9][0-9][0-9][0-9])-([0-9][0-9])-([0-9][0-9])(T([0-9][0-9]))?(:([0-9][0-9]))"
+                r"?(:([0-9][0-9]))?(\.[0-9][0-9][0-9][0-9][0-9][0-9])?"
+            ),
             date_string,
         )
         if match:
@@ -1245,8 +1247,7 @@ class datetime(date):
                 tz,
             )
             return result
-        else:
-            raise ValueError("Not a valid ISO Date")
+        raise ValueError("Not a valid ISO Date")
 
     @classmethod
     def now(cls, timezone=None):

--- a/examples/datetime_simpletest.py
+++ b/examples/datetime_simpletest.py
@@ -6,6 +6,7 @@
 #                         All rights reserved.
 # SPDX-FileCopyrightText: 1991-1995 Stichting Mathematisch Centrum. All rights reserved.
 # SPDX-FileCopyrightText: 2021 Brent Rubell for Adafruit Industries
+# SPDX-FileCopyrightText: 2021 Melissa LeBlanc-Williams for Adafruit Industries
 # SPDX-License-Identifier: Python-2.0
 
 # Example of working with a `datetime` object
@@ -28,3 +29,8 @@ for it in tt:
     print(it)
 
 print("Today is: ", dt.ctime())
+
+iso_date_string = "2020-04-05T05:04:45.752301"
+print("Creating new datetime from ISO Date:", iso_date_string)
+isodate = datetime.fromisoformat(iso_date_string)
+print("Formatted back out as ISO Date: ", isodate.isoformat())

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -88,6 +88,19 @@ class TestDate(unittest.TestCase):
         self.assertEqual(d.month, month)
         self.assertEqual(d.day, day)
 
+    def test_fromisoformat(self):
+        # Try an arbitrary fixed value.
+        iso_date_string = "1999-09-19"
+        d = cpy_date.fromisoformat(iso_date_string)
+        self.assertEqual(d.year, 1999)
+        self.assertEqual(d.month, 9)
+        self.assertEqual(d.day, 19)
+
+    def test_fromisoformat_bad_formats(self):
+        # Try an arbitrary fixed value.
+        self.assertRaises(ValueError, cpy_date.fromisoformat, "99-09-19")
+        self.assertRaises(ValueError, cpy_date.fromisoformat, "1999-13-19")
+
     # TODO: Test this when timedelta is added in
     @unittest.skip("Skip for CircuitPython - timedelta() not yet implemented.")
     def test_today(self):

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -1095,8 +1095,6 @@ class TestDateTime(TestDate):
                 dt_rt = self.theclass.fromisoformat(dtstr)
                 assert dt == dt_rt, dt_rt
 
-    # TODO
-    @unittest.skip("fromisoformat not implemented")
     def test_fromisoformat_separators(self):
         separators = [
             " ",
@@ -1118,8 +1116,6 @@ class TestDateTime(TestDate):
                 dt_rt = self.theclass.fromisoformat(dtstr)
                 self.assertEqual(dt, dt_rt)
 
-    # TODO
-    @unittest.skip("fromisoformat not implemented")
     def test_fromisoformat_ambiguous(self):
         # Test strings like 2018-01-31+12:15 (where +12:15 is not a time zone)
         separators = ["+", "-"]
@@ -1215,7 +1211,6 @@ class TestDateTime(TestDate):
 
         self.assertIs(dt.tzinfo, timezone.utc)
 
-    @unittest.skip("fromisoformat not implemented")
     def test_fromisoformat_subclass(self):
         class DateTimeSubclass(self.theclass):
             pass

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -1033,8 +1033,6 @@ class TestDateTime(TestDate):
                 self.assertIsInstance(dt, DateTimeSubclass)
                 self.assertEqual(dt.extra, 7)
 
-    # TODO
-    @unittest.skip("timezone not implemented")
     def test_fromisoformat_datetime(self):
         # Test that isoformat() is reversible
         base_dates = [(1, 1, 1), (1900, 1, 1), (2004, 11, 12), (2017, 5, 30)]

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -1128,7 +1128,7 @@ class TestDateTime(TestDate):
                 self.assertEqual(dt, dt_rt)
 
     # TODO
-    @unittest.skip("fromisoformat not implemented")
+    @unittest.skip("_format_time not fully implemented")
     def test_fromisoformat_timespecs(self):
         datetime_bases = [(2009, 12, 4, 8, 17, 45, 123456), (2009, 12, 4, 8, 17, 45, 0)]
 
@@ -1193,14 +1193,12 @@ class TestDateTime(TestDate):
                 with self.assertRaises(ValueError):
                     self.theclass.fromisoformat(bad_str)
 
-    # TODO
-    @unittest.skip("fromisoformat not implemented")
     def test_fromisoformat_fails_surrogate(self):
         # Test that when fromisoformat() fails with a surrogate character as
         # the separator, the error message contains the original string
         dtstr = "2018-01-03\ud80001:0113"
 
-        with self.assertRaisesRegex(ValueError, re.escape(repr(dtstr))):
+        with self.assertRaisesRegex(ValueError, repr(dtstr)):
             self.theclass.fromisoformat(dtstr)
 
     # TODO

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -1161,8 +1161,6 @@ class TestDateTime(TestDate):
                         dt_rt = self.theclass.fromisoformat(dtstr)
                         self.assertEqual(dt, dt_rt)
 
-    # TODO
-    @unittest.skip("fromisoformat not implemented")
     def test_fromisoformat_fails_datetime(self):
         # Test that fromisoformat() fails on invalid values
         bad_strs = [
@@ -1219,7 +1217,6 @@ class TestDateTime(TestDate):
 
         self.assertIs(dt.tzinfo, timezone.utc)
 
-    # TODO
     @unittest.skip("fromisoformat not implemented")
     def test_fromisoformat_subclass(self):
         class DateTimeSubclass(self.theclass):


### PR DESCRIPTION
Unfortunately CircuitPython doesn't yet support Counted Repetitions or Non-Capturing groups, so the regex is on the longer side.