### PR TITLE
datetime: fix _fromtimestamp for small-range floats

### DIFF
--- a/adafruit_datetime.py
+++ b/adafruit_datetime.py
@@ -1283,7 +1283,10 @@ class datetime(date):
         """Construct a datetime from a POSIX timestamp (like time.time()).
         A timezone info object may be passed in as well.
         """
-        frac, t = _math.modf(t)
+        if isinstance(t, float):
+            frac, t = _math.modf(t)
+        else:
+            frac, t = 0, t
         us = round(frac * 1e6)
         if us >= 1000000:
             t += 1

--- a/adafruit_datetime.py
+++ b/adafruit_datetime.py
@@ -1286,7 +1286,7 @@ class datetime(date):
         if isinstance(t, float):
             frac, t = _math.modf(t)
         else:
-            frac, t = 0, t
+            frac = 0
         us = round(frac * 1e6)
         if us >= 1000000:
             t += 1


### PR DESCRIPTION
A typical timestamp is 1614803568. A CircuitPython float's granularity at this magnitude is several minutes!

By avoiding the use of modf when t is an integer, the `datetime.now()` classmethod is usable, i.e., it returns a time that increases from second to second instead of mostly being stuck and occasionally jumping forward.