### PR TITLE
Create timezone.dst() with return None for timetuple() fix

### DIFF
--- a/adafruit_datetime.py
+++ b/adafruit_datetime.py
@@ -609,6 +609,13 @@ class tzinfo:
         """Return the time zone name corresponding to the datetime object dt, as a string."""
         raise NotImplementedError("tzinfo subclass must override tzname()")
 
+    def dst(self, dt: "datetime") -> None:  # pylint: disable=unused-argument
+        """Return the DST setting correspinding to the datetime object dt, as a number.
+
+        DST usage is currently not implemented for this library.
+        """
+        return None
+
     # tzinfo is an abstract base class, disabling for self._offset
     # pylint: disable=no-member
     def fromutc(self, dt: "datetime") -> "datetime":


### PR DESCRIPTION
Fixes #18, which was failing because `timezone` didn't have a default `dst()` to use if a timezone was provided.  New behavior based on issue test code:

```python
>>> import adafruit_datetime
>>> dt = adafruit_datetime.datetime(2022, 7, 13,  13, 30, 15 , 0, adafruit_datetime.timezone.utc)
>>> dt.ctime()
'Wed Jul 13 13:30:15 2022'
>>> dt.timetuple()
time.struct_time(tm_year=2022, tm_mon=7, tm_mday=13, tm_hour=13, tm_min=30, tm_sec=15, tm_wday=2, tm_yday=194, tm_isdst=-1)
```