### PR TITLE
Fix pylint errors

### DIFF
--- a/adafruit_datetime.py
+++ b/adafruit_datetime.py
@@ -628,7 +628,7 @@ class tzinfo:
 
         dtoff = dt.utcoffset()
         if dtoff is None:
-            raise ValueError("fromutc() requires a non-None utcoffset() " "result")
+            raise ValueError("fromutc() requires a non-None utcoffset() result")
         return dt + self._offset
 
 
@@ -841,7 +841,7 @@ class timezone(tzinfo):
             )
         if offset.microseconds != 0 or offset.seconds % 60 != 0:
             raise ValueError(
-                "offset must be a timedelta" " representing a whole number of minutes"
+                "offset must be a timedelta representing a whole number of minutes"
             )
         cls._offset = offset
         cls._name = name
@@ -860,14 +860,14 @@ class timezone(tzinfo):
     def utcoffset(self, dt: Optional["datetime"]) -> timedelta:
         if isinstance(dt, datetime) or dt is None:
             return self._offset
-        raise TypeError("utcoffset() argument must be a datetime instance" " or None")
+        raise TypeError("utcoffset() argument must be a datetime instance or None")
 
     def tzname(self, dt: Optional["datetime"]) -> str:
         if isinstance(dt, datetime) or dt is None:
             if self._name is None:
                 return self._name_from_offset(self._offset)
             return self._name
-        raise TypeError("tzname() argument must be a datetime instance" " or None")
+        raise TypeError("tzname() argument must be a datetime instance or None")
 
     # Comparison to other timezone objects
     def __eq__(self, other: Any) -> bool:
@@ -1362,7 +1362,7 @@ class datetime(date):
             result = tz.fromutc(result)
         return result
 
-    ## pylint: disable=arguments-differ
+    ## pylint: disable=arguments-differ, arguments-renamed
     @classmethod
     def fromtimestamp(
         cls, timestamp: float, tz: Optional["tzinfo"] = None

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -9,7 +9,7 @@
 # SPDX-License-Identifier: Python-2.0
 # Implements a subset of https://github.com/python/cpython/blob/master/Lib/test/datetimetester.py
 # NOTE: This test is based off CPython and therefore linting is disabled within this file.
-# pylint:disable=invalid-name, no-member, wrong-import-position, undefined-variable, no-self-use, cell-var-from-loop, misplaced-comparison-constant, too-many-public-methods, fixme, import-outside-toplevel, unused-argument, too-few-public-methods
+# pylint:disable=invalid-name, no-member, wrong-import-position, undefined-variable, no-self-use, cell-var-from-loop, too-many-public-methods, fixme, import-outside-toplevel, unused-argument, too-few-public-methods
 import sys
 import unittest
 
@@ -225,7 +225,7 @@ class TestDate(unittest.TestCase):
 
     def test_format(self):
         dt = cpy_date(2007, 9, 10)
-        self.assertEqual(dt.__format__(""), str(dt))
+        self.assertEqual(format(dt, ""), str(dt))
 
         # check that a derived class's __str__() gets called
         class A(cpy_date):
@@ -233,7 +233,7 @@ class TestDate(unittest.TestCase):
                 return "A"
 
         a = A(2007, 9, 10)
-        self.assertEqual(a.__format__(""), "A")
+        self.assertEqual(format(a, ""), "A")
 
         # check that a derived class's strftime gets called
         class B(cpy_date):
@@ -241,7 +241,7 @@ class TestDate(unittest.TestCase):
                 return "B"
 
         b = B(2007, 9, 10)
-        self.assertEqual(b.__format__(""), str(dt))
+        self.assertEqual(format(b, ""), str(dt))
 
         # date strftime not implemented in CircuitPython, skip
         """for fmt in ["m:%m d:%d y:%y",

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -239,10 +239,10 @@ class TestDateTime(TestDate):
     @unittest.skip("strftime not implemented in datetime")
     def test_format(self):
         dt = self.theclass(2007, 9, 10, 4, 5, 1, 123)
-        self.assertEqual(dt.__format__(""), str(dt))
+        self.assertEqual(format(dt, ""), str(dt))
 
         with self.assertRaisesRegex(TypeError, "must be str, not int"):
-            dt.__format__(123)
+            format(dt, 123)
 
         # check that a derived class's __str__() gets called
         class A(self.theclass):
@@ -250,7 +250,7 @@ class TestDateTime(TestDate):
                 return "A"
 
         a = A(2007, 9, 10, 4, 5, 1, 123)
-        self.assertEqual(a.__format__(""), "A")
+        self.assertEqual(format(a, ""), "A")
 
         # check that a derived class's strftime gets called
         class B(self.theclass):
@@ -258,16 +258,16 @@ class TestDateTime(TestDate):
                 return "B"
 
         b = B(2007, 9, 10, 4, 5, 1, 123)
-        self.assertEqual(b.__format__(""), str(dt))
+        self.assertEqual(format(b, ""), str(dt))
 
         for fmt in [
             "m:%m d:%d y:%y",
             "m:%m d:%d y:%y H:%H M:%M S:%S",
             "%z %Z",
         ]:
-            self.assertEqual(dt.__format__(fmt), dt.strftime(fmt))
-            self.assertEqual(a.__format__(fmt), dt.strftime(fmt))
-            self.assertEqual(b.__format__(fmt), "B")
+            self.assertEqual(format(dt, fmt), dt.strftime(fmt))
+            self.assertEqual(format(a, fmt), dt.strftime(fmt))
+            self.assertEqual(format(b, fmt), "B")
 
     @unittest.skip("ctime not implemented")
     def test_more_ctime(self):

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -237,10 +237,10 @@ class TestTime(HarmlessMixedComparison, unittest.TestCase):
     @unittest.skip("strftime not implemented for CircuitPython time objects")
     def test_format(self):
         t = self.theclass(1, 2, 3, 4)
-        self.assertEqual(t.__format__(""), str(t))
+        self.assertEqual(format(t, ""), str(t))
 
         with self.assertRaisesRegex(TypeError, "must be str, not int"):
-            t.__format__(123)
+            format(t, 123)
 
         # check that a derived class's __str__() gets called
         class A(self.theclass):
@@ -248,7 +248,7 @@ class TestTime(HarmlessMixedComparison, unittest.TestCase):
                 return "A"
 
         a = A(1, 2, 3, 4)
-        self.assertEqual(a.__format__(""), "A")
+        self.assertEqual(format(a, ""), "A")
 
         # check that a derived class's strftime gets called
         class B(self.theclass):
@@ -256,14 +256,14 @@ class TestTime(HarmlessMixedComparison, unittest.TestCase):
                 return "B"
 
         b = B(1, 2, 3, 4)
-        self.assertEqual(b.__format__(""), str(t))
+        self.assertEqual(format(b, ""), str(t))
 
         for fmt in [
             "%H %M %S",
         ]:
-            self.assertEqual(t.__format__(fmt), t.strftime(fmt))
-            self.assertEqual(a.__format__(fmt), t.strftime(fmt))
-            self.assertEqual(b.__format__(fmt), "B")
+            self.assertEqual(format(t, fmt), t.strftime(fmt))
+            self.assertEqual(format(a, fmt), t.strftime(fmt))
+            self.assertEqual(format(b, fmt), "B")
 
     def test_str(self):
         self.assertEqual(str(self.theclass(1, 2, 3, 4)), "01:02:03.000004")


### PR DESCRIPTION
Fixes the following `pylint` errors:

```
Error: pylint (library code)....................................................Failed
- hook id: pylint
- exit code: 4

************* Module adafruit_datetime
Error: adafruit_datetime.py:631:0: W1404: Implicit string concatenation found in call (implicit-str-concat)
Error: adafruit_datetime.py:844:0: W1404: Implicit string concatenation found in call (implicit-str-concat)
Error: adafruit_datetime.py:863:0: W1404: Implicit string concatenation found in call (implicit-str-concat)
Error: adafruit_datetime.py:870:0: W1404: Implicit string concatenation found in call (implicit-str-concat)
Error: adafruit_datetime.py:1367:4: W0237: Parameter 't' has been renamed to 'timestamp' in overridden 'datetime.fromtimestamp' method (arguments-renamed)

-----------------------------------
Your code has been rated at 9.95/10

pylint (example code)....................................................Passed
Error: pylint (test code).......................................................Failed
- hook id: pylint
- exit code: 20

************* Module test_date
Error: tests/test_date.py:12:0: W0012: Unknown option value for 'disable', expected a valid pylint message and got 'misplaced-comparison-constant' (unknown-option-value)
Error: tests/test_date.py:228:25: C2801: Unnecessarily calls dunder method __format__. Use format built-in function, format string method, or f-string. (unnecessary-dunder-call)
Error: tests/test_date.py:236:25: C2801: Unnecessarily calls dunder method __format__. Use format built-in function, format string method, or f-string. (unnecessary-dunder-call)
Error: tests/test_date.py:244:25: C2801: Unnecessarily calls dunder method __format__. Use format built-in function, format string method, or f-string. (unnecessary-dunder-call)
************* Module test_datetime
Error: tests/test_datetime.py:242:25: C2801: Unnecessarily calls dunder method __format__. Use format built-in function, format string method, or f-string. (unnecessary-dunder-call)
Error: tests/test_datetime.py:245:12: C2801: Unnecessarily calls dunder method __format__. Use format built-in function, format string method, or f-string. (unnecessary-dunder-call)
Error: tests/test_datetime.py:253:25: C2801: Unnecessarily calls dunder method __format__. Use format built-in function, format string method, or f-string. (unnecessary-dunder-call)
Error: tests/test_datetime.py:261:25: C2801: Unnecessarily calls dunder method __format__. Use format built-in function, format string method, or f-string. (unnecessary-dunder-call)
Error: tests/test_datetime.py:268:29: C2801: Unnecessarily calls dunder method __format__. Use format built-in function, format string method, or f-string. (unnecessary-dunder-call)
Error: tests/test_datetime.py:269:29: C2801: Unnecessarily calls dunder method __format__. Use format built-in function, format string method, or f-string. (unnecessary-dunder-call)
Error: tests/test_datetime.py:270:29: C2801: Unnecessarily calls dunder method __format__. Use format built-in function, format string method, or f-string. (unnecessary-dunder-call)
************* Module test_time
Error: tests/test_time.py:240:25: C2801: Unnecessarily calls dunder method __format__. Use format built-in function, format string method, or f-string. (unnecessary-dunder-call)
Error: tests/test_time.py:243:12: C2801: Unnecessarily calls dunder method __format__. Use format built-in function, format string method, or f-string. (unnecessary-dunder-call)
Error: tests/test_time.py:251:25: C2801: Unnecessarily calls dunder method __format__. Use format built-in function, format string method, or f-string. (unnecessary-dunder-call)
Error: tests/test_time.py:259:25: C2801: Unnecessarily calls dunder method __format__. Use format built-in function, format string method, or f-string. (unnecessary-dunder-call)
Error: tests/test_time.py:264:29: C2801: Unnecessarily calls dunder method __format__. Use format built-in function, format string method, or f-string. (unnecessary-dunder-call)
Error: tests/test_time.py:265:29: C2801: Unnecessarily calls dunder method __format__. Use format built-in function, format string method, or f-string. (unnecessary-dunder-call)
Error: tests/test_time.py:266:29: C2801: Unnecessarily calls dunder method __format__. Use format built-in function, format string method, or f-string. (unnecessary-dunder-call)

-----------------------------------
Your code has been rated at 9.86/10
```
