### PR TITLE
Note about timestamp() float precision.

### DIFF
--- a/adafruit_datetime.py
+++ b/adafruit_datetime.py
@@ -1525,7 +1525,7 @@ class datetime(date):
         Note that Floats on most boards are encoded in 30 bits
         internally, with effectively 22 bits of precision. As a result,
         for modern dates this value can be off by several minutes.
-        As a workaround you can access the function ``_mitime()``
+        As a workaround you can access the function ``_mktime()``
         to get an int version of the timestamp.
         """
         if not self._tzinfo is None:

--- a/adafruit_datetime.py
+++ b/adafruit_datetime.py
@@ -1522,11 +1522,11 @@ class datetime(date):
     def timestamp(self) -> float:
         """Return POSIX timestamp as float.
 
-        Note that Floats on most
-        boards are encoded in 30 bits internally, with effectively 22
-        bits of precision. As a result, for modern dates this value
-        can be off by several minutes. As a workaround you can access
-        the function ``_mitime()`` to get an int version of the timestamp.
+        Note that Floats on most boards are encoded in 30 bits
+        internally, with effectively 22 bits of precision. As a result,
+        for modern dates this value can be off by several minutes.
+        As a workaround you can access the function ``_mitime()``
+        to get an int version of the timestamp.
         """
         if not self._tzinfo is None:
             return (self - _EPOCH).total_seconds()

--- a/adafruit_datetime.py
+++ b/adafruit_datetime.py
@@ -1520,7 +1520,14 @@ class datetime(date):
         return _ymd2ord(self._year, self._month, self._day)
 
     def timestamp(self) -> float:
-        "Return POSIX timestamp as float"
+        """Return POSIX timestamp as float.
+
+        Note that Floats on most
+        boards are encoded in 30 bits internally, with effectively 22
+        bits of precision. As a result, for modern dates this value
+        can be off by several minutes. As a workaround you can access
+        the function ``_mitime()`` to get an int version of the timestamp.
+        """
         if not self._tzinfo is None:
             return (self - _EPOCH).total_seconds()
         s = self._mktime()


### PR DESCRIPTION
@ladyada 
The float precision issue has been reported a few times #24, #29 

As suggested in #29, this change adds a note to the `timestamp()` docstring about it as a warning to people, and offers a workaround.